### PR TITLE
Blockupdate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,6 +826,7 @@ dependencies = [
  "rayon",
  "smartstring",
  "uuid",
+ "vek",
 ]
 
 [[package]]

--- a/feather/common/Cargo.toml
+++ b/feather/common/Cargo.toml
@@ -23,3 +23,4 @@ libcraft-core = { path = "../../libcraft/core" }
 rayon = "1.5"
 worldgen = { path = "../worldgen", package = "feather-worldgen" }
 rand = "0.8"
+vek = "0.14"

--- a/feather/common/src/block.rs
+++ b/feather/common/src/block.rs
@@ -8,9 +8,11 @@ use base::{
     SimplifiedBlockKind, SlabKind,
 };
 use blocks::BlockKind;
-use ecs::{SysResult, SystemExecutor};
-use libcraft_core::BlockFace;
+use ecs::{Ecs, SysResult, SystemExecutor};
+use libcraft_core::{BlockFace, EntityKind};
 use quill_common::events::BlockPlacementEvent;
+use vek::Rect3;
+
 
 pub fn register(systems: &mut SystemExecutor<Game>) {
     systems.add_system(block_placement);
@@ -39,7 +41,7 @@ pub fn block_placement(game: &mut Game) -> SysResult {
             Some(s) => s,
             None => continue,
         };
-        if let Some(s) = place_block(&mut game.world, *pos, &game.chunk_entities, block, event) {
+        if let Some(s) = place_block(&mut game.world, *pos, &game.chunk_entities, block, event, &game.ecs) {
             match *gamemode {
                 Gamemode::Survival | Gamemode::Adventure => decrease_slot(&mut slot),
                 _ => {}
@@ -63,6 +65,7 @@ fn place_block(
     chunk_entities: &ChunkEntities,
     block: BlockId,
     placement: &BlockPlacementEvent,
+    game: &Ecs,
 ) -> Option<Vec<BlockChangeEvent>> {
     let target1 = placement.location;
     let target_block1 = world.block_at(target1)?;
@@ -114,12 +117,35 @@ fn place_block(
         }
         None => false,
     };
+    // This works but there is a discrepancy between when the place block event is fired and getting the entity location.
+    // that makes it possible to place a block at the right exact moment and have the server believe it wasn't blocked.
     if chunk_entities
         .entities_in_chunk(target.chunk())
         .iter()
-        .any(|_entity| false)
+        .any(|_entity| {
+            let entity_position = game.get::<Position>(*_entity).unwrap();
+            let entity_kind = *game.get::<EntityKind>(*_entity).unwrap();
+            let block_rect: Rect3<f64, f64> = vek::Rect3 {
+                x: target.x.into(),
+                y: target.y.into(),
+                z: target.z.into(),
+                w: 1.0,
+                h: 1.0,
+                d: 1.0,
+            };
+
+            let mut entity_rect = entity_kind.bounding_box().into_rect3();
+            entity_rect.x = entity_position.x - (entity_rect.w / 2.0);
+            entity_rect.y = entity_position.y;
+            entity_rect.z = entity_position.z - (entity_rect.d / 2.0);
+
+            if block_rect.collides_with_rect3(entity_rect) {
+                true
+            } else {
+                false
+            }
+        })
     {
-        // FIXME: Somehow check if block would collide with any entities
         return None;
     }
     if !world.check_block_stability(block, target)? {

--- a/feather/common/src/block.rs
+++ b/feather/common/src/block.rs
@@ -65,7 +65,7 @@ fn place_block(
     chunk_entities: &ChunkEntities,
     block: BlockId,
     placement: &BlockPlacementEvent,
-    game: &Ecs,
+    ecs: &Ecs,
 ) -> Option<Vec<BlockChangeEvent>> {
     let target1 = placement.location;
     let target_block1 = world.block_at(target1)?;
@@ -123,8 +123,8 @@ fn place_block(
         .entities_in_chunk(target.chunk())
         .iter()
         .any(|_entity| {
-            let entity_position = game.get::<Position>(*_entity).unwrap();
-            let entity_kind = *game.get::<EntityKind>(*_entity).unwrap();
+            let entity_position = ecs.get::<Position>(*_entity).unwrap();
+            let entity_kind = *ecs.get::<EntityKind>(*_entity).unwrap();
             let block_rect: Rect3<f64, f64> = vek::Rect3 {
                 x: target.x.into(),
                 y: target.y.into(),

--- a/feather/common/src/block.rs
+++ b/feather/common/src/block.rs
@@ -13,7 +13,6 @@ use libcraft_core::{BlockFace, EntityKind};
 use quill_common::events::BlockPlacementEvent;
 use vek::Rect3;
 
-
 pub fn register(systems: &mut SystemExecutor<Game>) {
     systems.add_system(block_placement);
 }
@@ -41,7 +40,14 @@ pub fn block_placement(game: &mut Game) -> SysResult {
             Some(s) => s,
             None => continue,
         };
-        if let Some(s) = place_block(&mut game.world, *pos, &game.chunk_entities, block, event, &game.ecs) {
+        if let Some(s) = place_block(
+            &mut game.world,
+            *pos,
+            &game.chunk_entities,
+            block,
+            event,
+            &game.ecs,
+        ) {
             match *gamemode {
                 Gamemode::Survival | Gamemode::Adventure => decrease_slot(&mut slot),
                 _ => {}
@@ -139,11 +145,7 @@ fn place_block(
             entity_rect.y = entity_position.y;
             entity_rect.z = entity_position.z - (entity_rect.d / 2.0);
 
-            if block_rect.collides_with_rect3(entity_rect) {
-                true
-            } else {
-                false
-            }
+            block_rect.collides_with_rect3(entity_rect)
         })
     {
         return None;

--- a/feather/server/src/systems/player_join.rs
+++ b/feather/server/src/systems/player_join.rs
@@ -7,6 +7,7 @@ use common::{
     ChatBox, Game, Window,
 };
 use ecs::{SysResult, SystemExecutor};
+use libcraft_core::EntityKind;
 use quill_common::{components::Name, entity_init::EntityInit};
 
 use crate::{ClientId, Server};
@@ -52,7 +53,8 @@ fn accept_new_player(game: &mut Game, server: &mut Server, client_id: ClientId) 
         .add(ChatBox::new(ChatPreference::All))
         .add(inventory)
         .add(window)
-        .add(HotbarSlot::default());
+        .add(HotbarSlot::default())
+        .add(EntityKind::Player);
 
     game.spawn_entity(builder);
 


### PR DESCRIPTION
# Add Entity detection when placing blocks, making it impossible to place blocks if there is an entity in the way.

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description



## Related issues

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [x] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.